### PR TITLE
Static assets settings

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 django = "*"
 pylint = "*"
 djangorestframework = "*"
+whitenoise = "*"
 
 [scripts]
 server = "python manage.py runserver"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "814b9984f05c37609833bcbe8d946972396f182c9c4f879de8688a30e942ac49"
+            "sha256": "a8c2c1228a1b7975d3f90b1612ce53c88dbed19aaf840c54e66c8f5082c7128c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,6 +127,14 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
+        },
+        "whitenoise": {
+            "hashes": [
+                "sha256:05ce0be39ad85740a78750c86a93485c40f08ad8c62a6006de0233765996e5c7",
+                "sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d"
+            ],
+            "index": "pypi",
+            "version": "==5.2.0"
         },
         "wrapt": {
             "hashes": [

--- a/acmprofiles/settings.py
+++ b/acmprofiles/settings.py
@@ -45,6 +45,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Simplified static file serving.
+    # https://warehouse.python.org/project/whitenoise/
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -134,3 +137,9 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
+# Simplified static file serving.
+# https://warehouse.python.org/project/whitenoise/
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+

--- a/acmprofiles/settings.py
+++ b/acmprofiles/settings.py
@@ -142,4 +142,3 @@ STATICFILES_DIRS = (
 # https://warehouse.python.org/project/whitenoise/
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-

--- a/static/tmp.txt
+++ b/static/tmp.txt
@@ -1,0 +1,1 @@
+Just a temp file to get this folder committed to Git


### PR DESCRIPTION
Add whitenoise from https://devcenter.heroku.com/articles/django-assets to hopefully resolve the issues that we are having with collectstatic.

Also added a `static` folder so that Heroku can find it.