### PR TITLE
add heroku to allowed hosts

### DIFF
--- a/acmprofiles/settings.py
+++ b/acmprofiles/settings.py
@@ -28,7 +28,9 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.environ["DEBUG"] == "True")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "acm-profiles-api.herokuapp.com"
+]
 
 CORS_ALLOWED_ORIGINS = [
     os.environ["FRONT_END_URL"]


### PR DESCRIPTION
django makes me cry

on another note, heroku is now part of the allowed hosts

localhost was automatically allowed so we didn't figure this out before